### PR TITLE
 update character limit for team messages

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -9,7 +9,7 @@ namespace RazorPagesTestSample.Data
 
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion

--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -43,19 +43,9 @@ namespace RazorPagesTestSample.Pages
                 return Page();
             }
 
-            if (Message.Text.Length > 250)
-            {
-                ModelState.AddModelError("Message.Text", "The message must be less than 250 characters");
-                Messages = await _db.GetMessagesAsync();
+            await _db.AddMessageAsync(Message);
 
-                return Page();
-            }
-            else
-            {
-                await _db.AddMessageAsync(Message);
-
-                return RedirectToPage();
-            }
+            return RedirectToPage();
         }
 
         public async Task<IActionResult> OnPostDeleteAllMessagesAsync()

--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -43,9 +43,19 @@ namespace RazorPagesTestSample.Pages
                 return Page();
             }
 
-            await _db.AddMessageAsync(Message);
+            if (Message.Text.Length > 250)
+            {
+                ModelState.AddModelError("Message.Text", "The message must be less than 250 characters");
+                Messages = await _db.GetMessagesAsync();
 
-            return RedirectToPage();
+                return Page();
+            }
+            else
+            {
+                await _db.AddMessageAsync(Message);
+
+                return RedirectToPage();
+            }
         }
 
         public async Task<IActionResult> OnPostDeleteAllMessagesAsync()

--- a/src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
+++ b/src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.7.0" />

--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs
@@ -49,6 +49,25 @@ namespace RazorPagesTestSample.Tests.UnitTests
         }
 
         [Fact]
+        public async Task AddMessageAsync_MessageIsNotAdded_WhenMessageExceedsCharacterLimit()
+        {
+            using (var db = new AppDbContext(Utilities.TestDbContextOptions()))
+            {
+                // Arrange
+                var recId = 11;
+                var longText = new string('a', 251); // 251 characters
+                var message = new Message() { Id = recId, Text = longText };
+
+                // Act & Assert
+                await db.AddMessageAsync(message);
+
+                // Ensure the message was not added
+                var actualMessage = await db.FindAsync<Message>(recId);
+                Assert.Null(actualMessage);
+            }
+        }
+
+        [Fact]
         public async Task DeleteAllMessagesAsync_MessagesAreDeleted()
         {
             using (var db = new AppDbContext(Utilities.TestDbContextOptions()))


### PR DESCRIPTION
This pull request includes several significant changes across different areas of the project, such as workflow automation, validation logic, and test coverage enhancements. The most important changes are summarized below:

### Workflow Automation:

* Added a new workflow for manual trigger and issue events in `.github/workflows/first-workflow.yml`. This workflow includes two jobs: `echo_job` and `cowsay_job`, which run sequentially. (`[.github/workflows/first-workflow.ymlR1-R26](diffhunk://#diff-9e5979a33e7e1ecefb014de62234e10c3dd743accfee6f666fd41cb16d002f6eR1-R26)`)
* Removed the workflow for deploying a Jekyll site to GitHub Pages in `.github/workflows/pages.yml`. This included removing jobs for building and deploying the site. (`[.github/workflows/pages.ymlL1-L62](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L1-L62)`)

### Validation Logic:

* Updated the `StringLength` attribute for the `Text` property in the `Message` class to increase the character limit from 200 to 250 in `src/Application/src/RazorPagesTestSample/Data/Message.cs`. (`[src/Application/src/RazorPagesTestSample/Data/Message.csL12-R12](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450L12-R12)`)
* Added validation logic in the `OnPostAddMessageAsync` method to ensure the message text does not exceed 250 characters in `src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs`. (`[src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.csR46-R59](diffhunk://#diff-253887119f1aeea8f5bd6fecc53ddcd5cd2d601f4e80af86ffaf52338d40f7d4R46-R59)`)

### Test Coverage Enhancements:

* Updated the `Newtonsoft.Json` package version from `11.0.2` to `13.0.1` in the test project file `src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csproj`. (`[src/Application/tests/RazorPagesTestSample.Tests/RazorPagesTestSample.Tests.csprojL16-R16](diffhunk://#diff-efe86dcc91504869b45b309717a619ec91df87c2846842b0ce920831d425d941L16-R16)`)
* Added a new unit test to verify that messages exceeding the character limit are not added to the database in `src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.cs`. (`[src/Application/tests/RazorPagesTestSample.Tests/UnitTests/DataAccessLayerTest.csR51-R69](diffhunk://#diff-759cd6dbf2cedcb026f64771a32e9837bd979c7b48a52cae4dbd208ece5a69b4R51-R69)`)